### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ jabba use ...
 $envRegKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SYSTEM\CurrentControlSet\Control\Session Manager\Environment', $true)
 $envPath=$envRegKey.GetValue('Path', $null, "DoNotExpandEnvironmentNames").replace('%JAVA_HOME%\bin;', '')
 [Environment]::SetEnvironmentVariable('JAVA_HOME', "$(jabba which $(jabba current))", 'Machine')
-[Environment]::SetEnvironmentVariable('PATH', "%JAVA_HOME%\bin;$envPath", 'Machine')
+[Environment]::SetEnvironmentVariable('PATH', "$envPath;%JAVA_HOME%\bin", 'Machine')
 ```
 
 * Linux


### PR DESCRIPTION
`%JAVA_HOME%\bin` cannot be expanded unless laid after $envPath under Windows 10